### PR TITLE
Expose prefersEphemeralWebBrowserSession for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,12 @@ npx cap sync
 ### authenticate(...)
 
 ```typescript
-authenticate(options: { url: string; customScheme?: string; }) => any
+authenticate(options: AuthenticateOptions): Promise<AuthenticateResponse>
 ```
 
-| Param         | Type                                                 |
-| ------------- | ---------------------------------------------------- |
-| **`options`** | <code>{ url: string; customScheme?: string; }</code> |
-
-**Returns:** <code>any</code>
-
---------------------
+| Interface | Type |
+| --- | --- |
+| **`AuthenticateOptions`** | <code>{ url: string; customScheme?: string; prefersEphemeralWebBrowserSession?: boolean }</code> |
+| **`AuthenticateResponse`** | <code>{ url: string; }</code> |
 
 </docgen-api>

--- a/ios/Plugin/SingleSignOnPlugin.swift
+++ b/ios/Plugin/SingleSignOnPlugin.swift
@@ -13,13 +13,14 @@ public class SingleSignOnPlugin: CAPPlugin, ASWebAuthenticationPresentationConte
            return UIApplication.shared.keyWindow!
         }
     }
-    
+
     private var session: Any?
 
     @objc func authenticate(_ call: CAPPluginCall) {
         let url = call.getString("url") ?? ""
         let scheme = call.getString("customScheme") ?? ""
-        
+        let prefersEphemeralWebBrowserSession = call.getBool("prefersEphemeralWebBrowserSession", false)
+
         if #available(iOS 12.0, *) {
             self.session = ASWebAuthenticationSession.init(url: URL(string: url)!, callbackURLScheme: scheme, completionHandler: { url, error in
                 if (error != nil) {
@@ -32,6 +33,7 @@ public class SingleSignOnPlugin: CAPPlugin, ASWebAuthenticationPresentationConte
                 }
             })
             if #available(iOS 13.0, *) {
+                (self.session as! ASWebAuthenticationSession).prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
                 (self.session as! ASWebAuthenticationSession).presentationContextProvider = self
             }
             (self.session as! ASWebAuthenticationSession).start()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,8 +1,13 @@
+interface AuthenticateOptions {
+    url: string;
+    customScheme?: string;
+    prefersEphemeralWebBrowserSession?: boolean;
+}
+
+interface AuthenticateResponse {
+    url: string;
+}
+
 export interface SingleSignOnPlugin {
-    authenticate(
-        options: {
-            url: string;
-            customScheme?: string;
-        }
-    ): Promise<{ url: string }>;
+    authenticate(options: AuthenticateOptions): Promise<AuthenticateResponse>;
 }


### PR DESCRIPTION
This PR exposes `prefersEphemeralWebBrowserSession` for iOS.

[Read this](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio) for why it is useful.